### PR TITLE
Add runhaskell image

### DIFF
--- a/dex-images/runhaskell/Dockerfile
+++ b/dex-images/runhaskell/Dockerfile
@@ -1,0 +1,7 @@
+FROM haskell:8
+
+ENTRYPOINT ["runhaskell"]
+
+LABEL \
+  org.dockerland.dex.api="v1" \
+  org.dockerland.dex.docker_flags="--interactive --tty"


### PR DESCRIPTION
The only way we will ever get to use haskell at work... without its dependencies!

This will only allow scripts that don't depend on packages outside of `base`, but that's not terrible. I'm not sure how we would go about `dex`ifying the image with respect to [stack](https://docs.haskellstack.org/en/stable/README/) to allow adding cabal package dependencies, since it's such a relative-to-directory & `$HOME` type of tool. Better to keep simple for now.

Once installed, people can start scripting via ` #!/usr/bin/env runhaskell`