### PR TITLE
Update haskell scripting entrypoint

### DIFF
--- a/dex-images/stack/Dockerfile
+++ b/dex-images/stack/Dockerfile
@@ -1,6 +1,6 @@
 FROM haskell:8
 
-ENTRYPOINT ["runhaskell"]
+ENTRYPOINT ["stack"]
 
 LABEL \
   org.dockerland.dex.api="v1" \


### PR DESCRIPTION
@briceburg turns out stack supports scripting with [individual build directives](https://github.com/SamTay/haskell-fun-times/blob/master/playground/scripting/fsnotify.hs#L1-L2). Solves the problems discussed in #3 and is just plain awesome.